### PR TITLE
Added postgres-extension option to rdkit installer

### DIFF
--- a/install-rdkit
+++ b/install-rdkit
@@ -179,11 +179,13 @@ function main
                 -D PYTHON_INCLUDE_DIR=/usr/include/python3.6m \
                 -D PYTHON_EXECUTABLE=/usr/bin/python3.6 \
                 $numpy_cmake_option \
-                -D RDK_BUILD_INCHI_SUPPORT=ON ..
+                -D RDK_BUILD_INCHI_SUPPORT=ON \
+                -D RDK_BUILD_PGSQL="${postgres_ext}" ..
             ;;
         2.7)
             debug "Running cmake for Python ${python_version}..."
-            cmake -DRDK_BUILD_INCHI_SUPPORT=ON ..
+            cmake -DRDK_BUILD_INCHI_SUPPORT=ON \
+                  -D RDK_BUILD_PGSQL="${postgres_ext}" ..
             ;;
     esac
 
@@ -256,6 +258,11 @@ function print_help
 		        installation of RDKit in. If you have a virtual environment
 		        activated it will default to that. It will ensure the virtual
 		        environment has numpy installed.
+
+		    --postgres-extension
+		        Build RDKit with optional postgres cartridge. (Must have
+			postgresql-server-dev installed PostgreSQL_ROOT environment
+			variable set.)
 		
 		    -d, --debug
 		        Print debugging output while running.
@@ -301,7 +308,7 @@ function parse_opts
     #   LONGOPTS=source:,debug,test
     #
     OPTIONS=r:p:e:dh
-    LONGOPTS=release:,python-version:,virtual-env:,debug,help
+    LONGOPTS=release:,python-version:,virtual-env:,debug,help,postgres-extension
 
     # Use ! and PIPESTATUS to get exit code with errexit set.
     # Temporarily store output to be able to check for errors.
@@ -344,6 +351,10 @@ function parse_opts
                 venv="${2}"
                 shift 2
                 ;;
+	    --postgres-extension)
+		postgres_ext="ON"
+		shift
+		;;
             -d|--debug)
                 DEBUG=true
                 shift
@@ -362,6 +373,11 @@ function parse_opts
                 ;;
         esac
     done
+
+    if [ -z "${postgres_ext}" ]
+    then
+	    postgres_ext="OFF"
+    fi
 
     if [ -z "${1}" ]
     then


### PR DESCRIPTION
created --postgres-extension option which creates a `postgres-ext` variable that is set to `ON` or `OFF` based on the command line option which is then passed to the `-D RDK_BUILD_PGSQL` option of the cmake step.