### PR TITLE
add support for python 3.10 under ubuntu 22.04

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig for rdkit-installer
+#
+# See https://editorconfig.org/
+
+[*]
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+# Set default charset
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/install-rdkit
+++ b/install-rdkit
@@ -20,9 +20,9 @@ function main
     if [ -z "${python_version}" ]
     then
         case "$(lsb_release -rs)" in
-	    22.04)
-		default_python_version=3.10
-		;;
+            22.04)
+                default_python_version=3.10
+                ;;
             20.04)
                 default_python_version=3.8
                 ;;
@@ -50,9 +50,9 @@ function main
     esac
 
     case "$(lsb_release -rs)" in
-	22.04)
-	    freetype_apt_package=libfreetype-dev
-	    ;;
+        22.04)
+            freetype_apt_package=libfreetype-dev
+            ;;
         20.04)
             freetype_apt_package=libfreetype-dev
             ;;
@@ -137,8 +137,8 @@ function main
         then
             boost_version=1.67
         elif [[ "$(lsb_release -rs)" == '22.04' ]]
-	then
-	    boost_version=1.74
+        then
+            boost_version=1.74
         fi
     fi
 
@@ -286,10 +286,10 @@ function main
             # Based on the advanced install instructions in the RDKit online
             # docs with paths changed to match Ubuntu Linux file locations:
             # https://www.rdkit.org/docs/Install.html#advanced
-	    #
-	    # rdkit ships with a version of catch2 that is broken on ubuntu
-	    # 22.04, so in a python 3.10 install we override to use the system
-	    # copy
+            #
+            # rdkit ships with a version of catch2 that is broken on ubuntu
+            # 22.04, so in a python 3.10 install we override to use the system
+            # copy
 
             cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.10.so \
                 -D PYTHON_INCLUDE_DIR=/usr/include/python3.10 \

--- a/install-rdkit
+++ b/install-rdkit
@@ -59,6 +59,7 @@ function main
             # RDKit ships with a version of catch2 that is broken in Ubuntu
             # 22.04, so we tell cmake to use the system copy.
             catch2_apt_package=catch2
+            # This option is added to the cmake call below.
             cmake_catch_option='-D CATCH_DIR=/usr/include/catch2'
             ;;
         20.04)
@@ -257,78 +258,43 @@ function main
     debug "Current directory for build: ${PWD}"
 
     case "${python_version}" in
-        3.10)
+        2.7)
+            debug "Running cmake for Python ${python_version}..."
+            cmake -D RDK_BUILD_INCHI_SUPPORT=ON \
+                  -D RDK_BUILD_PGSQL="${build_psql}" ..
+            check_err $? 'ERROR: cmake failed. See output above for details.'
+            ;;
+        3.6|3.7)
             debug "Running cmake for Python ${python_version}..."
             debug "numpy_cmake_option: $numpy_cmake_option"
             # Based on the advanced install instructions in the RDKit online
             # docs with paths changed to match Ubuntu Linux file locations:
             # https://www.rdkit.org/docs/Install.html#advanced
-            #
-            # Ubuntu 22.04 only has (as of launch) Python 3.10, so we start
-            # adding the catch option here.
-            cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.10.so \
-                -D PYTHON_INCLUDE_DIR=/usr/include/python3.10 \
-                -D PYTHON_EXECUTABLE=/usr/bin/python3.10 \
+            cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython${python_version}m.so \
+                -D PYTHON_INCLUDE_DIR=/usr/include/python${python_version}m \
+                -D PYTHON_EXECUTABLE=/usr/bin/python${python_version} \
+                $numpy_cmake_option \
+                -D RDK_BUILD_INCHI_SUPPORT=ON \
+                -D RDK_BUILD_PGSQL="${build_psql}" \
+                -D PostgreSQL_TYPE_INCLUDE_DIR="/usr/include/postgresql/${postgresql_version}/server" \
+                -D PostgreSQL_ROOT="${postgresql_root}" ..
+            check_err $? 'ERROR: cmake failed. See output above for details.'
+            ;;
+        *)
+            debug "Running cmake for Python ${python_version}..."
+            debug "numpy_cmake_option: $numpy_cmake_option"
+            # Based on the advanced install instructions in the RDKit online
+            # docs with paths changed to match Ubuntu Linux file locations:
+            # https://www.rdkit.org/docs/Install.html#advanced
+            cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython${python_version}.so \
+                -D PYTHON_INCLUDE_DIR=/usr/include/python${python_version} \
+                -D PYTHON_EXECUTABLE=/usr/bin/python${python_version} \
                 $numpy_cmake_option \
                 -D RDK_BUILD_INCHI_SUPPORT=ON \
                 $cmake_catch_option \
                 -D RDK_BUILD_PGSQL="${build_psql}" \
                 -D PostgreSQL_TYPE_INCLUDE_DIR="/usr/include/postgresql/${postgresql_version}/server" \
                 -D PostgreSQL_ROOT="${postgresql_root}" ..
-            check_err $? 'ERROR: cmake failed. See output above for details.'
-            ;;
-        3.8)
-            debug "Running cmake for Python ${python_version}..."
-            debug "numpy_cmake_option: $numpy_cmake_option"
-            # Based on the advanced install instructions in the RDKit online
-            # docs with paths changed to match Ubuntu Linux file locations:
-            # https://www.rdkit.org/docs/Install.html#advanced
-            cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.8.so \
-                -D PYTHON_INCLUDE_DIR=/usr/include/python3.8 \
-                -D PYTHON_EXECUTABLE=/usr/bin/python3.8 \
-                $numpy_cmake_option \
-                -D RDK_BUILD_INCHI_SUPPORT=ON \
-                -D RDK_BUILD_PGSQL="${build_psql}" \
-                -D PostgreSQL_TYPE_INCLUDE_DIR="/usr/include/postgresql/${postgresql_version}/server" \
-                -D PostgreSQL_ROOT="${postgresql_root}" ..
-            check_err $? 'ERROR: cmake failed. See output above for details.'
-            ;;
-        3.7)
-            debug "Running cmake for Python ${python_version}..."
-            debug "numpy_cmake_option: $numpy_cmake_option"
-            # Based on the advanced install instructions in the RDKit online
-            # docs with paths changed to match Ubuntu Linux file locations:
-            # https://www.rdkit.org/docs/Install.html#advanced
-            cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.7m.so \
-                -D PYTHON_INCLUDE_DIR=/usr/include/python3.7m \
-                -D PYTHON_EXECUTABLE=/usr/bin/python3.7 \
-                $numpy_cmake_option \
-                -D RDK_BUILD_INCHI_SUPPORT=ON \
-                -D RDK_BUILD_PGSQL="${build_psql}" \
-                -D PostgreSQL_TYPE_INCLUDE_DIR="/usr/include/postgresql/${postgresql_version}/server" \
-                -D PostgreSQL_ROOT="${postgresql_root}" ..
-            check_err $? 'ERROR: cmake failed. See output above for details.'
-            ;;
-        3.6)
-            debug "Running cmake for Python ${python_version}..."
-            debug "numpy_cmake_option: $numpy_cmake_option"
-            # Based on the advanced install instructions in the RDKit online
-            # docs with paths changed to match Ubuntu Linux file locations:
-            # https://www.rdkit.org/docs/Install.html#advanced
-            cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.6m.so \
-                -D PYTHON_INCLUDE_DIR=/usr/include/python3.6m \
-                -D PYTHON_EXECUTABLE=/usr/bin/python3.6 \
-                $numpy_cmake_option \
-                -D RDK_BUILD_INCHI_SUPPORT=ON \
-                -D RDK_BUILD_PGSQL="${build_psql}" \
-                -D PostgreSQL_TYPE_INCLUDE_DIR="/usr/include/postgresql/${postgresql_version}/server" \
-                -D PostgreSQL_ROOT="${postgresql_root}" ..
-            check_err $? 'ERROR: cmake failed. See output above for details.'
-            ;;
-        2.7)
-            debug "Running cmake for Python ${python_version}..."
-            cmake -D RDK_BUILD_INCHI_SUPPORT=ON \
-                  -D RDK_BUILD_PGSQL="${build_psql}" ..
             check_err $? 'ERROR: cmake failed. See output above for details.'
             ;;
     esac

--- a/install-rdkit
+++ b/install-rdkit
@@ -42,7 +42,7 @@ function main
     fi
 
     case "${python_version}" in
-        2.7|3.6|3.7|3.8|3.10)
+        2.7|3.6|3.7|3.8|3.9|3.10)
             ;;
         *)
             die "ERROR: Invalid or unsupported Python version: ${python_version}"
@@ -136,9 +136,6 @@ function main
         if [[ "$(lsb_release -rs)" == '20.04' ]]
         then
             boost_version=1.67
-        elif [[ "$(lsb_release -rs)" == '22.04' ]]
-        then
-            boost_version=1.74
         fi
     fi
 

--- a/install-rdkit
+++ b/install-rdkit
@@ -20,6 +20,9 @@ function main
     if [ -z "${python_version}" ]
     then
         case "$(lsb_release -rs)" in
+	    22.04)
+		default_python_version=3.10
+		;;
             20.04)
                 default_python_version=3.8
                 ;;
@@ -39,7 +42,7 @@ function main
     fi
 
     case "${python_version}" in
-        2.7|3.6|3.7|3.8)
+        2.7|3.6|3.7|3.8|3.10)
             ;;
         *)
             die "ERROR: Invalid or unsupported Python version: ${python_version}"
@@ -47,6 +50,9 @@ function main
     esac
 
     case "$(lsb_release -rs)" in
+	22.04)
+	    freetype_apt_package=libfreetype-dev
+	    ;;
         20.04)
             freetype_apt_package=libfreetype-dev
             ;;
@@ -130,7 +136,18 @@ function main
         if [[ "$(lsb_release -rs)" == '20.04' ]]
         then
             boost_version=1.67
+        elif [[ "$(lsb_release -rs)" == '22.04' ]]
+	then
+	    boost_version=1.74
         fi
+    fi
+
+    # if under ubuntu 22.04, we need to install and use catch2
+    if [[ "$(lsb_release -rs)" == '22.04' ]]
+    then
+        catch2_apt_package=catch2
+    else
+        catch2_apt_package=''
     fi
 
     if [ ! -d "${install_dir}" ]
@@ -164,7 +181,7 @@ function main
     # (https://github.com/rdkit/rdkit_containers/blob/master/docker/ubuntu_bionic/Dockerfile).
     #
     sudo apt-get install -y \
-        wget build-essential cmake "libboost${boost_version}-all-dev" ${freetype_apt_package}
+        wget build-essential cmake "libboost${boost_version}-all-dev" ${freetype_apt_package} ${catch2_apt_package}
     check_err $? 'Could not install required system packages.'
 
     if [[ $build_psql == ON ]]
@@ -174,6 +191,12 @@ function main
     check_err $? 'Could not install required system packages.'
 
     case "${python_version}" in
+        3.10)
+            debug "Installing Python ${python_version} packages..."
+            sudo apt-get install -y \
+                python3.10 python3.10-dev python3-numpy
+            check_err $? 'Could not install required system packages.'
+            ;;
         3.8)
             debug "Installing Python ${python_version} packages..."
             sudo apt-get install -y \
@@ -257,6 +280,28 @@ function main
     debug "Current directory for build: ${PWD}"
 
     case "${python_version}" in
+        3.10)
+            debug "Running cmake for Python ${python_version}..."
+            debug "numpy_cmake_option: $numpy_cmake_option"
+            # Based on the advanced install instructions in the RDKit online
+            # docs with paths changed to match Ubuntu Linux file locations:
+            # https://www.rdkit.org/docs/Install.html#advanced
+	    #
+	    # rdkit ships with a version of catch2 that is broken on ubuntu
+	    # 22.04, so in a python 3.10 install we override to use the system
+	    # copy
+
+            cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.10.so \
+                -D PYTHON_INCLUDE_DIR=/usr/include/python3.10 \
+                -D PYTHON_EXECUTABLE=/usr/bin/python3.10 \
+                $numpy_cmake_option \
+                -D RDK_BUILD_INCHI_SUPPORT=ON \
+                -D CATCH_DIR=/usr/include/catch2 \
+                -D RDK_BUILD_PGSQL="${build_psql}" \
+                -D PostgreSQL_TYPE_INCLUDE_DIR="/usr/include/postgresql/${postgresql_version}/server" \
+                -D PostgreSQL_ROOT="${postgresql_root}" ..
+            check_err $? 'ERROR: cmake failed. See output above for details.'
+            ;;
         3.8)
             debug "Running cmake for Python ${python_version}..."
             debug "numpy_cmake_option: $numpy_cmake_option"

--- a/install-rdkit
+++ b/install-rdkit
@@ -228,8 +228,6 @@ function main
     tmpdir="$(mktemp -d)"
     cd "${tmpdir}"
 
-    archive_url="https://github.com/rdkit/rdkit/archive/${release}.tar.gz"
-
     wget "https://github.com/rdkit/rdkit/archive/${release}.tar.gz"
     check_err $? 'RDKit release could not be downloaded.'
 

--- a/install-rdkit
+++ b/install-rdkit
@@ -177,44 +177,44 @@ function main
     # installs the above list and more), so we switched to that
     # (https://github.com/rdkit/rdkit_containers/blob/master/docker/ubuntu_bionic/Dockerfile).
     #
-    sudo apt-get install -y \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
         wget build-essential cmake "libboost${boost_version}-all-dev" ${freetype_apt_package} ${catch2_apt_package}
     check_err $? 'Could not install required system packages.'
 
     if [[ $build_psql == ON ]]
     then
-        sudo apt-get install -y postgresql-server-dev-${postgresql_version}
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y postgresql-server-dev-${postgresql_version}
     fi
     check_err $? 'Could not install required system packages.'
 
     case "${python_version}" in
         3.10)
             debug "Installing Python ${python_version} packages..."
-            sudo apt-get install -y \
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 python3.10 python3.10-dev python3-numpy
             check_err $? 'Could not install required system packages.'
             ;;
         3.8)
             debug "Installing Python ${python_version} packages..."
-            sudo apt-get install -y \
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 python3.8 python3.8-dev python3-numpy
             check_err $? 'Could not install required system packages.'
             ;;
         3.7)
             debug "Installing Python ${python_version} packages..."
-            sudo apt-get install -y \
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 python3.7 python3.7-dev python3-numpy
             check_err $? 'Could not install required system packages.'
             ;;
         3.6)
             debug "Installing Python ${python_version} packages..."
-            sudo apt-get install -y \
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 python3.6 python3.6-dev python3-numpy
             check_err $? 'Could not install required system packages.'
             ;;
         2.7)
             debug "Installing Python ${python_version} packages..."
-            sudo apt-get install -y \
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 python2.7 python2.7-dev python-numpy
             check_err $? 'Could not install required system packages.'
             ;;

--- a/install-rdkit
+++ b/install-rdkit
@@ -49,9 +49,17 @@ function main
             ;;
     esac
 
+    freetype_apt_package=''
+    catch2_apt_package=''
+    cmake_catch_option=''
     case "$(lsb_release -rs)" in
         22.04)
             freetype_apt_package=libfreetype-dev
+
+            # RDKit ships with a version of catch2 that is broken in Ubuntu
+            # 22.04, so we tell cmake to use the system copy.
+            catch2_apt_package=catch2
+            cmake_catch_option='-D CATCH_DIR=/usr/include/catch2'
             ;;
         20.04)
             freetype_apt_package=libfreetype-dev
@@ -137,14 +145,6 @@ function main
         then
             boost_version=1.67
         fi
-    fi
-
-    # if under ubuntu 22.04, we need to install and use catch2
-    if [[ "$(lsb_release -rs)" == '22.04' ]]
-    then
-        catch2_apt_package=catch2
-    else
-        catch2_apt_package=''
     fi
 
     if [ ! -d "${install_dir}" ]
@@ -282,16 +282,14 @@ function main
             # docs with paths changed to match Ubuntu Linux file locations:
             # https://www.rdkit.org/docs/Install.html#advanced
             #
-            # rdkit ships with a version of catch2 that is broken on ubuntu
-            # 22.04, so in a python 3.10 install we override to use the system
-            # copy
-
+            # Ubuntu 22.04 only has (as of launch) Python 3.10, so we start
+            # adding the catch option here.
             cmake -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.10.so \
                 -D PYTHON_INCLUDE_DIR=/usr/include/python3.10 \
                 -D PYTHON_EXECUTABLE=/usr/bin/python3.10 \
                 $numpy_cmake_option \
                 -D RDK_BUILD_INCHI_SUPPORT=ON \
-                -D CATCH_DIR=/usr/include/catch2 \
+                $cmake_catch_option \
                 -D RDK_BUILD_PGSQL="${build_psql}" \
                 -D PostgreSQL_TYPE_INCLUDE_DIR="/usr/include/postgresql/${postgresql_version}/server" \
                 -D PostgreSQL_ROOT="${postgresql_root}" ..

--- a/install-rdkit
+++ b/install-rdkit
@@ -188,34 +188,16 @@ function main
     check_err $? 'Could not install required system packages.'
 
     case "${python_version}" in
-        3.10)
-            debug "Installing Python ${python_version} packages..."
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-                python3.10 python3.10-dev python3-numpy
-            check_err $? 'Could not install required system packages.'
-            ;;
-        3.8)
-            debug "Installing Python ${python_version} packages..."
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-                python3.8 python3.8-dev python3-numpy
-            check_err $? 'Could not install required system packages.'
-            ;;
-        3.7)
-            debug "Installing Python ${python_version} packages..."
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-                python3.7 python3.7-dev python3-numpy
-            check_err $? 'Could not install required system packages.'
-            ;;
-        3.6)
-            debug "Installing Python ${python_version} packages..."
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-                python3.6 python3.6-dev python3-numpy
-            check_err $? 'Could not install required system packages.'
-            ;;
         2.7)
             debug "Installing Python ${python_version} packages..."
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
                 python2.7 python2.7-dev python-numpy
+            check_err $? 'Could not install required system packages.'
+            ;;
+        *)
+            debug "Installing Python ${python_version} packages..."
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+                python${python_version} python${python_version}-dev python3-numpy
             check_err $? 'Could not install required system packages.'
             ;;
     esac


### PR DESCRIPTION
These changes allow the script to run under Ubuntu 22.04, which so far only has support for Python 3.10.4.  I have more or less just tweaked what was available.  The only specific thing is the `catch2` library, which needs to be installed for rdkit to build properly under 22.04.

I only tested this script under 22.04 and release=Release_2021_09_5.  It may break on other versions of the OS & rdkit, but I hope it doesn't.